### PR TITLE
Add surport for setting customized gdb binary

### DIFF
--- a/autoload/gdbmgr.vim
+++ b/autoload/gdbmgr.vim
@@ -3436,7 +3436,10 @@ fun! s:GdbMgrSend(id,tgtfunc,...)
   " initialize GdbMgr
   elseif a:tgtfunc == "gmInit"
 "   call Decho("initializing GdbMgr: libcall'ing gdbmgr.so<".a:tgtfunc.">")
-   let response = libcall("gdbmgr.so",a:tgtfunc," ")
+   if !exists("g:gdbmgr_gdb_exe")
+      let g:gdbmgr_gdb_exe= "gdb"
+   endif
+   let response = libcall("gdbmgr.so",a:tgtfunc,g:gdbmgr_gdb_exe)
    call s:gdbmgr_registry_{t:gdbmgrtab}["M"].Update(response)
  
   else

--- a/gdbmgr/src/gdbmgr.c
+++ b/gdbmgr/src/gdbmgr.c
@@ -97,7 +97,7 @@ else if(pid == 0) { /* child process */
 	/* Will now exec gdb, thereby using it as the child process.
 	 */
 	Dprintf((fp,"(child) about to execlp \"gdb --annotate=3\"\n"));
-	if(execlp("gdb","gdb","--annotate=3",(char *) NULL) < 0) {
+	if(execlp(gdbcmd,gdbcmd,"--annotate=3",(char *) NULL) < 0) {
 		sprintf(gdbmgr->gdbmgrbuf,"***error*** %s",strerror(errno));
 		Rdbg((fp,"gmInit <%s> : (child) badexec",gdbmgr->gdbmgrbuf));
 		return gdbmgr->gdbmgrbuf;


### PR DESCRIPTION
For example,currently Rust use an customized gdb: rust-gdb.
You can set this in vimrc to enable rust-gdb:
let g:gdbmgr_gdb_exe='rust-gdb' 